### PR TITLE
build on ubuntu 14.04 and libusb version 0.1.12  some errors

### DIFF
--- a/src/usbnet.c
+++ b/src/usbnet.c
@@ -755,7 +755,7 @@ int usb_bulk_read(usb_dev_handle *dev, int ep, char *bytes, int size, int timeou
    return res;
 }
 
-int usb_bulk_write(usb_dev_handle *dev, int ep, usb_buf_t bytes, int size, int timeout)
+int usb_bulk_write(usb_dev_handle *dev, int ep, const char * bytes, int size, int timeout)
 {
    // Get remote fd
    Packet* pkt = pkt_claim();
@@ -786,7 +786,7 @@ int usb_bulk_write(usb_dev_handle *dev, int ep, usb_buf_t bytes, int size, int t
 /* libusb(5):
  * Interrupt transfers.
  */
-int usb_interrupt_write(usb_dev_handle *dev, int ep, usb_buf_t bytes, int size, int timeout)
+int usb_interrupt_write(usb_dev_handle *dev, int ep, const char * bytes, int size, int timeout)
 {
    // Get remote fd
    Packet* pkt = pkt_claim();


### PR DESCRIPTION
_$mkdir build
$cd build
$ cmake ..
$make_
some errors:

1 ~/libusbnet/src/usbnet.c:758:5:error : conflicting types for 'usb_bulk_write'
 /usr/include/usb.h:304:5: note:previous declaration of 'usb_bulk_write' was here
